### PR TITLE
Reduce Actions artifact storage

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           name: docker-image
           path: image.tar
+          retention-days: 1
 
   publish:
     needs: build

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -36,10 +36,12 @@ jobs:
 
       # Save the image for the publish job
       - name: Save Docker image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker save ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest > image.tar
 
       # Upload the image as an artifact
       - name: Upload Docker image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: docker-image
@@ -48,6 +50,7 @@ jobs:
 
   publish:
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: Production
     runs-on: ubuntu-latest
     


### PR DESCRIPTION
## What changed
- Retain Docker transfer artifacts for one day.
- Save and upload the image only for pushes to `main`.
- Run the publish job only for pushes to `main`; pull requests still build for validation.

## Why
Large Docker artifacts were accumulating in Actions storage, and pull requests did not need to publish the production `latest` image.

## Validation
Reviewed the workflow job dependencies and artifact upload/download path.